### PR TITLE
feat: `/attack-detection` endpoints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
   - repo: https://github.com/ambv/black
-    rev: 21.10b0
+    rev: 22.12.0
     hooks:
     - id: black
   - repo: https://github.com/commitizen-tools/commitizen

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -13,3 +13,4 @@ Keycloak resources
    resources/authentication
    resources/admin_events
    resources/sessions
+   resources/attack_detection

--- a/docs/resources/attack_detection.rst
+++ b/docs/resources/attack_detection.rst
@@ -1,0 +1,19 @@
+Attack detection
+=================
+
+.. automodule:: keycloak_admin_aio._resources.attack_detection
+
+.. autoclass:: keycloak_admin_aio._resources.attack_detection.AttackDetection
+   :members:
+
+Brute Force
+-----------
+
+.. autoclass:: keycloak_admin_aio._resources.attack_detection.brute_force.BruteForce
+   :members:
+
+.. autoclass:: keycloak_admin_aio._resources.attack_detection.brute_force.users.Users
+   :members:
+
+.. autoclass:: keycloak_admin_aio._resources.attack_detection.brute_force.users.by_id.UsersByIdBruteForceDetection
+   :members:

--- a/keycloak_admin_aio/_keycloak_admin_aio.py
+++ b/keycloak_admin_aio/_keycloak_admin_aio.py
@@ -11,6 +11,7 @@ from ._lib.utils import remove_none
 from ._resources import (
     AdminEvents,
     AttachedResources,
+    AttackDetection,
     Authentication,
     Clients,
     ClientScopes,
@@ -18,7 +19,6 @@ from ._resources import (
     Roles,
     Sessions,
     Users,
-    AttackDetection,
 )
 
 

--- a/keycloak_admin_aio/_keycloak_admin_aio.py
+++ b/keycloak_admin_aio/_keycloak_admin_aio.py
@@ -18,6 +18,7 @@ from ._resources import (
     Roles,
     Sessions,
     Users,
+    AttackDetection,
 )
 
 
@@ -37,6 +38,7 @@ class KeycloakAdmin:
         ("authentication", Authentication),
         ("groups", Groups),
         ("sessions", Sessions),
+        ("attack_detection", AttackDetection),
     ]
     roles: Roles
     """https://www.keycloak.org/docs-api/15.0/rest-api/index.html#_roles_resource"""
@@ -60,6 +62,9 @@ class KeycloakAdmin:
     """https://www.keycloak.org/docs-api/15.0/rest-api/index.html#_groups_resource"""
 
     sessions: Sessions
+
+    attack_detection: AttackDetection
+    """https://www.keycloak.org/docs-api/15.0/rest-api/index.html#_attack_detection_resource"""
 
     leeway: int
     """A token will be considered as expired seconds before its actual expiry controlled by this value."""

--- a/keycloak_admin_aio/_resources/__init__.py
+++ b/keycloak_admin_aio/_resources/__init__.py
@@ -15,3 +15,4 @@ from .groups import Groups
 from .roles import Roles
 from .users import Users
 from .sessions import Sessions
+from .attack_detection import AttackDetection

--- a/keycloak_admin_aio/_resources/attack_detection/__init__.py
+++ b/keycloak_admin_aio/_resources/attack_detection/__init__.py
@@ -1,0 +1,3 @@
+"""https://www.keycloak.org/docs-api/15.0/rest-api/index.html#_attack_detection_resource"""
+
+from .attack_detection import AttackDetection

--- a/keycloak_admin_aio/_resources/attack_detection/attack_detection.py
+++ b/keycloak_admin_aio/_resources/attack_detection/attack_detection.py
@@ -1,0 +1,12 @@
+from .brute_force import BruteForce
+from .. import KeycloakResource, AttachedResources
+
+
+class AttackDetection(KeycloakResource):
+    """Provides the Keycloak attack-detection resource."""
+
+    _keycloak_resources: AttachedResources = [("brute_force", BruteForce)]
+    brute_force: BruteForce
+
+    def get_url(self) -> str:
+        return f"{self._get_parent_url()}/attack-detection"

--- a/keycloak_admin_aio/_resources/attack_detection/attack_detection.py
+++ b/keycloak_admin_aio/_resources/attack_detection/attack_detection.py
@@ -1,5 +1,5 @@
+from .. import AttachedResources, KeycloakResource
 from .brute_force import BruteForce
-from .. import KeycloakResource, AttachedResources
 
 
 class AttackDetection(KeycloakResource):

--- a/keycloak_admin_aio/_resources/attack_detection/brute_force/__init__.py
+++ b/keycloak_admin_aio/_resources/attack_detection/brute_force/__init__.py
@@ -1,0 +1,1 @@
+from .brute_force import BruteForce

--- a/keycloak_admin_aio/_resources/attack_detection/brute_force/brute_force.py
+++ b/keycloak_admin_aio/_resources/attack_detection/brute_force/brute_force.py
@@ -1,0 +1,12 @@
+from ... import KeycloakResource, AttachedResources
+from .users import Users
+
+
+class BruteForce(KeycloakResource):
+    """Provides the Keycloak brute-force resource."""
+
+    _keycloak_resources: AttachedResources = [("users", Users)]
+    users: Users
+
+    def get_url(self) -> str:
+        return f"{self._get_parent_url()}/brute-force"

--- a/keycloak_admin_aio/_resources/attack_detection/brute_force/brute_force.py
+++ b/keycloak_admin_aio/_resources/attack_detection/brute_force/brute_force.py
@@ -1,4 +1,4 @@
-from ... import KeycloakResource, AttachedResources
+from ... import AttachedResources, KeycloakResource
 from .users import Users
 
 

--- a/keycloak_admin_aio/_resources/attack_detection/brute_force/users/__init__.py
+++ b/keycloak_admin_aio/_resources/attack_detection/brute_force/users/__init__.py
@@ -1,0 +1,1 @@
+from .users import Users

--- a/keycloak_admin_aio/_resources/attack_detection/brute_force/users/by_id/__init__.py
+++ b/keycloak_admin_aio/_resources/attack_detection/brute_force/users/by_id/__init__.py
@@ -1,0 +1,1 @@
+from .by_id import UsersByIdBruteForceDetection

--- a/keycloak_admin_aio/_resources/attack_detection/brute_force/users/by_id/by_id.py
+++ b/keycloak_admin_aio/_resources/attack_detection/brute_force/users/by_id/by_id.py
@@ -1,4 +1,5 @@
 from typing import Any
+
 from ..... import KeycloakResourceWithIdentifier
 
 

--- a/keycloak_admin_aio/_resources/attack_detection/brute_force/users/by_id/by_id.py
+++ b/keycloak_admin_aio/_resources/attack_detection/brute_force/users/by_id/by_id.py
@@ -1,0 +1,38 @@
+from typing import Any
+from ..... import KeycloakResourceWithIdentifier
+
+
+class UsersByIdBruteForceDetection(KeycloakResourceWithIdentifier):
+    """Provides the users by id on brute-force detection resource.
+
+    .. code:: python
+
+        from keycloak_admin_aio import KeycloakAdmin
+
+        kc: KeycloakAdmin  # needs to be instantiated
+        user_id: str  # uuid
+    """
+
+    def get_url(self) -> str:
+        return f"{self._get_parent_url()}/{self.identifier}"
+
+    async def get(self) -> dict[str, Any]:
+        """Get status of a user for brute-force detection.
+
+        .. code:: python
+
+            result: dict[str, Any] = await kc.attack_detection.brute_force.users.by_id(user_id).get()
+        """
+        connection = await self._get_connection()
+        response = await connection.get(self.get_url())
+        return response.json()
+
+    async def delete(self):
+        """Clear login failures for the user.
+
+        .. code:: python
+
+            await kc.attack_detection.brute_force.users.by_id(user_id).delete()
+        """
+        connection = await self._get_connection()
+        await connection.delete(self.get_url())

--- a/keycloak_admin_aio/_resources/attack_detection/brute_force/users/users.py
+++ b/keycloak_admin_aio/_resources/attack_detection/brute_force/users/users.py
@@ -1,4 +1,8 @@
-from .... import KeycloakResource, AttachedResources, KeycloakResourceWithIdentifierGetter
+from .... import (
+    AttachedResources,
+    KeycloakResource,
+    KeycloakResourceWithIdentifierGetter,
+)
 from .by_id import UsersByIdBruteForceDetection
 
 

--- a/keycloak_admin_aio/_resources/attack_detection/brute_force/users/users.py
+++ b/keycloak_admin_aio/_resources/attack_detection/brute_force/users/users.py
@@ -1,0 +1,29 @@
+from .... import KeycloakResource, AttachedResources, KeycloakResourceWithIdentifierGetter
+from .by_id import UsersByIdBruteForceDetection
+
+
+class Users(KeycloakResource):
+    """Provides the users on brute-force detection resource.
+
+    .. code:: python
+
+        from keycloak_admin_aio import KeycloakAdmin
+
+        kc: KeycloakAdmin  # needs to be instantiated
+    """
+
+    _keycloak_resources: AttachedResources = [("by_id", UsersByIdBruteForceDetection)]
+    by_id: KeycloakResourceWithIdentifierGetter[UsersByIdBruteForceDetection]
+
+    def get_url(self) -> str:
+        return f"{self._get_parent_url()}/users"
+
+    async def delete(self):
+        """Clear login failures for all users.
+
+        .. code:: python
+
+            await kc.attack_detection.brute_force.users.delete()
+        """
+        connection = await self._get_connection()
+        await connection.delete(self.get_url())

--- a/test/test_attack_detection.py
+++ b/test/test_attack_detection.py
@@ -1,7 +1,7 @@
 import httpx
 import pytest
+from fixtures import event_loop, keycloak_admin
 
-from fixtures import keycloak_admin, event_loop
 from keycloak_admin_aio import KeycloakAdmin, UserRepresentation
 
 

--- a/test/test_attack_detection.py
+++ b/test/test_attack_detection.py
@@ -1,0 +1,41 @@
+import httpx
+import pytest
+
+from fixtures import keycloak_admin, event_loop
+from keycloak_admin_aio import KeycloakAdmin, UserRepresentation
+
+
+@pytest.fixture
+async def user_id(keycloak_admin: KeycloakAdmin):
+    user_id = await keycloak_admin.users.create(
+        UserRepresentation(email="test@test.com", username="test")
+    )
+    yield user_id
+    await keycloak_admin.users.by_id(user_id).delete()
+
+
+@pytest.mark.asyncio
+async def test_get_brute_force_status(keycloak_admin: KeycloakAdmin, user_id: str):
+    status = await keycloak_admin.attack_detection.brute_force.users.by_id(
+        user_id
+    ).get()
+    assert status is not None
+    assert type(status) is dict
+
+
+@pytest.mark.asyncio
+async def test_clear_login_failures(keycloak_admin: KeycloakAdmin):
+    try:
+        await keycloak_admin.attack_detection.brute_force.users.delete()
+    except httpx.HTTPStatusError as ex:
+        assert False, ex
+
+
+@pytest.mark.asyncio
+async def test_clear_login_failures_for_user(
+    keycloak_admin: KeycloakAdmin, user_id: str
+):
+    try:
+        await keycloak_admin.attack_detection.brute_force.users.by_id(user_id).delete()
+    except httpx.HTTPStatusError as ex:
+        assert False, ex


### PR DESCRIPTION
Implements the [attack-detection resource](https://www.keycloak.org/docs-api/15.0/rest-api/index.html#_attack_detection_resource) which closes #6.

@anton-delphai Would you please review this PR and merge?

Greetings,
Nicklas